### PR TITLE
C#: Adjustments to CIL/nullness analyses

### DIFF
--- a/csharp/ql/src/semmle/code/cil/DataFlow.qll
+++ b/csharp/ql/src/semmle/code/cil/DataFlow.qll
@@ -88,7 +88,7 @@ private predicate localTaintStep(DataFlowNode src, DataFlowNode sink) {
 }
 
 cached
-private module DefUse {
+module DefUse {
   /**
    * A classification of variable references into reads and writes.
    */
@@ -185,21 +185,26 @@ private module DefUse {
     )
   }
 
-  /** Holds if the update `def` can be used at the read `use`. */
+  /** Holds if the variable update `vu` can be used at the read `use`. */
   cached
-  predicate defUseImpl(StackVariable target, DataFlowNode def, ReadAccess use) {
-    exists(VariableUpdate vu | def = vu.getSource() |
-      defReachesReadWithinBlock(target, vu, use)
-      or
-      exists(BasicBlock bb, int i |
-        exists(refRank(bb, i, target, Read())) and
-        use = bb.getNode(i) and
-        defReachesEndOfBlock(bb.getAPredecessor(), vu, target) and
-        not defReachesReadWithinBlock(target, _, use)
-      )
+  predicate variableUpdateUse(StackVariable target, VariableUpdate vu, ReadAccess use) {
+    defReachesReadWithinBlock(target, vu, use)
+    or
+    exists(BasicBlock bb, int i |
+      exists(refRank(bb, i, target, Read())) and
+      use = bb.getNode(i) and
+      defReachesEndOfBlock(bb.getAPredecessor(), vu, target) and
+      not defReachesReadWithinBlock(target, _, use)
     )
   }
+
+  /** Holds if the update `def` can be used at the read `use`. */
+  cached
+  predicate defUse(StackVariable target, Expr def, ReadAccess use) {
+    exists(VariableUpdate vu | def = vu.getSource() | variableUpdateUse(target, vu, use))
+  }
 }
+private import DefUse
 
 abstract library class VariableUpdate extends Instruction {
   abstract Expr getSource();
@@ -224,5 +229,3 @@ private class MethodOutOrRefTarget extends VariableUpdate, Call {
 
   override Expr getSource() { result = this }
 }
-
-predicate defUse = DefUse::defUseImpl/3;

--- a/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/DataFlow.qll
@@ -1188,7 +1188,7 @@ module DataFlow {
      * nodes that may potentially be reached in flow from some source to some
      * sink.
      */
-    module Pruning {
+    private module Pruning {
       /**
        * Holds if `node` is reachable from a source in the configuration `config`,
        * ignoring call contexts.

--- a/csharp/ql/test/library-tests/cil/dataflow/DataFlow.ql
+++ b/csharp/ql/test/library-tests/cil/dataflow/DataFlow.ql
@@ -1,7 +1,6 @@
 import csharp
 import semmle.code.csharp.dataflow.DataFlow::DataFlow
-// import DataFlow::PathGraph
- 
+
 class FlowConfig extends Configuration {
   FlowConfig() { this = "FlowConfig" }
 

--- a/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
+++ b/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
@@ -1,9 +1,11 @@
 alwaysNull
 | dataflow.cs:70:21:70:35 | default(...) |
+| dataflow.cs:74:21:74:34 | call to method NullFunction |
 | dataflow.cs:74:39:74:52 | call to method IndirectNull |
 | dataflow.cs:78:21:78:45 | call to method ReturnsNull |
 | dataflow.cs:79:21:79:46 | call to method ReturnsNull2 |
 | dataflow.cs:80:21:80:44 | access to property NullProperty |
+| dataflow.cs:89:31:89:44 | call to method NullFunction |
 alwaysNotNull
 | dataflow.cs:71:24:71:35 | default(...) |
 | dataflow.cs:72:27:72:30 | this access |

--- a/csharp/ql/test/library-tests/controlflow/guards/ExtractorOptions.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/ExtractorOptions.cs
@@ -1,0 +1,1 @@
+// semmle-extractor-options: --cil

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -952,6 +952,8 @@
 | D.cs:212:18:212:18 | access to local variable n | null | D.cs:211:20:211:23 | null | null |
 | D.cs:212:18:212:26 | ... == ... | false | D.cs:212:18:212:18 | access to local variable n | non-null |
 | D.cs:212:18:212:26 | ... == ... | true | D.cs:212:18:212:18 | access to local variable n | null |
+| D.cs:212:18:212:45 | ... ? ... : ... | non-null | D.cs:212:18:212:26 | ... == ... | true |
+| D.cs:212:18:212:45 | ... ? ... : ... | non-null | D.cs:212:30:212:41 | object creation of type Object | non-null |
 | D.cs:212:18:212:45 | ... ? ... : ... | null | D.cs:212:18:212:26 | ... == ... | false |
 | D.cs:212:18:212:45 | ... ? ... : ... | null | D.cs:212:45:212:45 | access to local variable n | null |
 | D.cs:212:45:212:45 | access to local variable n | non-null | D.cs:211:20:211:23 | null | non-null |


### PR DESCRIPTION
- Cache predicates in the same stage using a cached module.
- Introduce `DefUse::defUseVariableUpdate()` and use in `CallableReturns.qll`.
  The updated file `csharp/ql/test/library-tests/cil/dataflow/Nullness.expected`
  demonstrates why this is needed.
- Utilize CIL analysis in `Guards::nonNullValue()`.
- Analyze SSA definitions in `AlwaysNullExpr`, similar to `NonNullExpr`.